### PR TITLE
SPAM: Add README documentation for tag plates and hub setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# TuneERR Prototype ERR
+
+## Description
+This repository contains the TuneERR Prototype ERR project.
+
+## Tag Plates
+- Minimum of 6 tag plates
+- Preferred 12 plates (6 red, 6 blue)
+- Stickers applied according to the Game Manual
+
+## Hub Placement
+- Tag plates mounted on the hub in the shop
+- Clear visibility for alliance identification
+
+## Bonus
+- Quick-swap plate design for easy replacement


### PR DESCRIPTION
Fixes #13

- Added README documentation
- Documented tag plate requirements (6–12 plates)
- Included hub placement details
- Included hub placement details
- Added quick-swap bonus concept
